### PR TITLE
Bump core and web-ui versions

### DIFF
--- a/cytomine.template
+++ b/cytomine.template
@@ -15,7 +15,7 @@ global:
       PIMS: cytomineuliege/pims:bp-0.15.0
       POSTGIS: cytomine/postgis:15-3.3-alpine-1.2.1
       RABBITMQ: rabbitmq:3.10
-      WEB_UI: cytomine/web_ui:bp-0.1.0
+      WEB_UI: cytomineuliege/web_ui:bp-0.1.1
 
   urls: # add these urls to your /etc/hosts (mapping nginx container ip)
     constant:

--- a/cytomine.template
+++ b/cytomine.template
@@ -1,19 +1,21 @@
 global:
   versions:
     constant: 
-      CYTOMINE_COMMERCIAL: CE2023.1
+      CYTOMINE_COMMERCIAL: BP2024.1
 
   images:
     constant:
       BIOFORMAT: cytomine/bioformat:v1.2.0
-      CORE: cytomine/core:4.3.6
+      CORE: cytomine/core:bp-0.1.0
+      ELASTICSEARCH: docker.elastic.co/elasticsearch/elasticsearch:8.6.2
+      LOGSTASH: docker.elastic.co/logstash/logstash:8.6.2
       MONGO: mongo:4.4.18-focal
       NGINX: cytomine/nginx:1.22.1-1.2.0
       PIMS_CACHE: redis:7.0.8
-      PIMS: cytomine/pims:0.13.6
+      PIMS: cytomineuliege/pims:bp-0.15.0
       POSTGIS: cytomine/postgis:15-3.3-alpine-1.2.1
       RABBITMQ: rabbitmq:3.10
-      WEB_UI: cytomine/web_ui:2.6.1
+      WEB_UI: cytomine/web_ui:bp-0.1.0
 
   urls: # add these urls to your /etc/hosts (mapping nginx container ip)
     constant:
@@ -40,24 +42,6 @@ global:
 
 # -------------------------------------------------- # 
 # Only update variables below if you know what you are doing
-
-  versions:
-    constant: 
-      CYTOMINE_COMMERCIAL: CE2023.1
-
-  images:
-    constant:
-      BIOFORMAT: cytomine/bioformat:v1.2.0
-      CORE: cytomine/core:4.4.0
-      ELASTICSEARCH: docker.elastic.co/elasticsearch/elasticsearch:8.6.2
-      LOGSTASH: docker.elastic.co/logstash/logstash:8.6.2
-      MONGO: cytomine/mongo:0.1.0
-      NGINX: cytomine/nginx:2.0.0
-      PIMS_CACHE: redis:7.0.8
-      PIMS: cytomineuliege/pims:bp-0.15.0
-      POSTGIS: cytomine/postgis:1.3.0
-      RABBITMQ: rabbitmq:3.10
-      WEB_UI: cytomine/web_ui:2.6.2
 
   internal_docker_urls: # must match respective container hostnames from compose file
     constant: 
@@ -115,14 +99,6 @@ global:
     auto:
       IMAGE_SERVER_PRIVATE: random_uuid
       IMAGE_SERVER_PUBLIC: random_uuid
-
-  smtp:
-    constant:
-      HOST: mail.smtp
-      PORT: 587
-      USER: user
-      PASS: password
-      TEST: TT
 
 services:
   default:


### PR DESCRIPTION
## Description

- Set the commercial version to BP2024.1
- Bump core to version bp-0.1.0
- Bump web-ui to version bp-0.1.0
- Remove duplicate keys (image and smtp)
